### PR TITLE
Fix method symbol extraction in chunker

### DIFF
--- a/src/rag_service/chunker.py
+++ b/src/rag_service/chunker.py
@@ -115,8 +115,8 @@ class CodeChunker:
                 groups = match.groups()
                 symbol_name = None
                 for g in groups:
-                    if g and g not in ['async', 'const', 'function', ':']:
-                        symbol_name = g
+                    if g and g.strip() and g.strip() not in ['async', 'const', 'function', ':']:
+                        symbol_name = g.strip()
                         break
                 
                 boundaries.append({


### PR DESCRIPTION
## Summary
- ensure CodeChunker ignores indentation when extracting symbol names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_684a6d655eb08322b5ac67e88023ea32