### PR TITLE
Handle dict response from tool refinement

### DIFF
--- a/src/coding_agent/agent.py
+++ b/src/coding_agent/agent.py
@@ -365,6 +365,9 @@ Example:
                 temperature=0.1
             )
             
+            if isinstance(response, dict):
+                response = [response]
+
             if isinstance(response, list):
                 # Execute the requested tool calls
                 for tool_call in response[:5]:  # Limit to 5 calls

--- a/tests/test_agent_tool_response.py
+++ b/tests/test_agent_tool_response.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.coding_agent import CodingAgent
+from src.coding_agent.models import CodeContext
+from src.proto_gen import messages_pb2
+
+
+def test_refine_context_tool_response_dict(monkeypatch):
+    agent = CodingAgent(repo_path=".")
+    agent.llm_client = MagicMock()
+
+    response_dict = {"tool": "read_file", "args": {"path": "README.md"}}
+    agent.llm_client.generate_with_json.return_value = response_dict
+
+    executed = []
+
+    def mock_execute_tool_call(tool_call, context):
+        executed.append(tool_call)
+
+    monkeypatch.setattr(agent, "_execute_tool_call", mock_execute_tool_call)
+
+    task = messages_pb2.CodingTask()
+    task.goal = "dummy"
+
+    context = CodeContext(task_goal="dummy")
+    agent._refine_context_with_tools(task, context)
+
+    assert executed == [response_dict]


### PR DESCRIPTION
## Summary
- support dict result from LLM tool recommendations
- add regression test for dict tool response

## Testing
- `pytest tests/test_agent_tool_response.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tree_sitter_go')*

------
https://chatgpt.com/codex/tasks/task_e_684a6ed3d4688322941637d997c98a58