### PR TITLE
Normalize RAG file paths

### DIFF
--- a/src/core/path_utils.py
+++ b/src/core/path_utils.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def normalize_repo_path(path: str | Path, repo_root: str | Path) -> str:
+    """Return the path relative to the repository root if possible."""
+    abs_path = Path(path).resolve()
+    try:
+        return str(abs_path.relative_to(Path(repo_root).resolve()))
+    except Exception:
+        return str(abs_path)

--- a/src/request_planner/enhanced_context.py
+++ b/src/request_planner/enhanced_context.py
@@ -35,7 +35,9 @@ class EnhancedContextRetriever:
             try:
                 # Create RAG service with repo-specific persistence
                 rag_dir = repo_path / ".rag"
-                rag_service = RAGService(persist_directory=str(rag_dir))
+                rag_service = RAGService(
+                    persist_directory=str(rag_dir), repo_path=str(self.repo_path)
+                )
                 self.rag_client = RAGClient(service=rag_service)
                 
                 # Check if index exists, if not, index the repo

--- a/test_rag.py
+++ b/test_rag.py
@@ -29,7 +29,7 @@ def test_rag_service():
     
     # Initialize RAG service
     print("1. Initializing RAG service...")
-    rag_service = RAGService(persist_directory=".test_rag")
+    rag_service = RAGService(persist_directory=".test_rag", repo_path=".")
     rag_client = RAGClient(service=rag_service)
     
     # Check if available

--- a/tests/test_coding_agent.py
+++ b/tests/test_coding_agent.py
@@ -193,7 +193,9 @@ def test_coding_agent_with_rag():
         # Initialize RAG service
         print("\n🔍 Initializing RAG service...")
         rag_dir = test_repo / ".rag"
-        rag_service = RAGService(persist_directory=str(rag_dir))
+        rag_service = RAGService(
+            persist_directory=str(rag_dir), repo_path=str(test_repo)
+        )
         rag_client = RAGClient(service=rag_service)
         
         if rag_client.is_available():

--- a/tests/test_path_normalization.py
+++ b/tests/test_path_normalization.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from src.rag_service import RAGService, RAGClient
+from src.code_planner.rag_integration import CodePlannerRAGIntegration
+from src.proto_gen import messages_pb2
+
+
+def _mock_embedding_service(service: RAGService):
+    dim = service.embedding_service.dimension
+    service.embedding_service.enabled = True
+    service.embedding_service.embed_batch = lambda texts: [[0.1] * dim for _ in texts]
+    service.embedding_service.embed_text = lambda text: [0.1] * dim
+
+
+def test_search_with_normalized_path(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    file_path = repo / "foo.py"
+    file_path.write_text("def foo():\n" + "pass\n" * 60)
+
+    rag_dir = repo / ".rag"
+    service = RAGService(persist_directory=str(rag_dir), repo_path=str(repo))
+    _mock_embedding_service(service)
+    client = RAGClient(service=service)
+
+    service.index_directory(str(repo), extensions=[".py"])
+
+    results = client.search("foo", filters={"file_path": "foo.py"})
+    assert results, "relative path filter should return results"
+
+    abs_path = str(file_path.resolve())
+    integration = CodePlannerRAGIntegration(str(repo), rag_client=client)
+    step = messages_pb2.Step(goal="edit", kind=messages_pb2.STEP_KIND_EDIT)
+    blobs = integration.prefetch_blobs_for_step(step, [abs_path], k=1)
+    assert blobs, "prefetch should normalize absolute paths"
+
+


### PR DESCRIPTION
## Summary
- keep repository root in `RAGService`
- normalize file paths when indexing and querying
- ensure context gatherers use normalized paths
- add helper util `normalize_repo_path`
- test search with file_path filters using path normalization

## Testing
- `pytest tests/test_path_normalization.py -v`

------
https://chatgpt.com/codex/tasks/task_e_684a71e9fb4c8322a46d26d25b818268