### PR TITLE
Enable smart context gatherer in CodingAgent

### DIFF
--- a/docs/AGENT_RAG_INTEGRATION_STATUS.md
+++ b/docs/AGENT_RAG_INTEGRATION_STATUS.md
@@ -35,11 +35,11 @@ We've been implementing RAG (Retrieval-Augmented Generation) service integration
   - Automatic repository indexing
 
 ### 🚧 Coding Agent RAG Integration
-- **Status**: Structure created, core components implemented
+- **Status**: In progress, smart context gathering available
 - **Implementation**: `src/coding_agent/`
 - **Completed**:
   - Models and data structures
-  - Context gatherer with RAG integration
+  - Basic and smart context gatherers
   - Git operations wrapper
   - Patch validator
 - **TODO**:

--- a/src/coding_agent/__init__.py
+++ b/src/coding_agent/__init__.py
@@ -12,6 +12,7 @@ The Coding Agent is responsible for:
 from .agent import CodingAgent
 from .models import CommitStatus, CommitResult, CodeContext, PatchResult, ValidationResult
 from .context_gatherer import ContextGatherer
+from .context_gatherer_v2 import SmartContextGatherer
 from .patch_generator import PatchGenerator
 from .validator import PatchValidator
 from .git_operations import GitOperations
@@ -24,6 +25,7 @@ __all__ = [
     "PatchResult",
     "ValidationResult",
     "ContextGatherer",
+    "SmartContextGatherer",
     "PatchGenerator",
     "PatchValidator",
     "GitOperations"

--- a/src/coding_agent/agent.py
+++ b/src/coding_agent/agent.py
@@ -19,6 +19,7 @@ import json
 from ..proto_gen import messages_pb2
 from .models import CommitStatus, CommitResult, CodeContext
 from .context_gatherer import ContextGatherer
+from .context_gatherer_v2 import SmartContextGatherer
 from .patch_generator import PatchGenerator
 from .file_rewriter import FileRewriter
 from .validator import PatchValidator
@@ -40,7 +41,8 @@ class CodingAgent:
         repo_path: str,
         rag_client=None,
         llm_client=None,
-        max_retries: int = 2
+        max_retries: int = 2,
+        use_smart_context: bool = False
     ):
         """
         Initialize the Coding Agent.
@@ -50,14 +52,18 @@ class CodingAgent:
             rag_client: Optional RAG client for context
             llm_client: Optional LLM client for generation
             max_retries: Maximum patch generation retries
+            use_smart_context: Use SmartContextGatherer if True
         """
         self.repo_path = Path(repo_path)
         self.max_retries = max_retries
         self.llm_client = llm_client
         self.rag_client = rag_client
-        
+
         # Initialize components
-        self.context_gatherer = ContextGatherer(repo_path, rag_client)
+        if use_smart_context:
+            self.context_gatherer = SmartContextGatherer(repo_path, rag_client)
+        else:
+            self.context_gatherer = ContextGatherer(repo_path, rag_client)
         self.patch_generator = PatchGenerator(llm_client)
         self.file_rewriter = FileRewriter(llm_client, repo_path)
         self.validator = PatchValidator(repo_path)


### PR DESCRIPTION
## Summary
- expose `SmartContextGatherer`
- allow `CodingAgent` to optionally use the smart gatherer
- document coding agent RAG integration progress

## Testing
- `pytest tests/test_agent_tool_response.py::test_refine_context_tool_response_dict -q` *(fails: ImportError: cannot import name 'messages_pb2')*

------
https://chatgpt.com/codex/tasks/task_e_684a6e64316483228f9e6e2b2cec7202